### PR TITLE
Implement simple collision detection for trip counter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import './App.css';
 import * as src from './static/hermeus-thumbnail.jpg';
 import { motion, useAnimation } from 'framer-motion';
@@ -27,10 +27,11 @@ function Animation() {
   let rightBound = 0;
   const altitude = 50;
 
-  const trips = 0;
+  const [leftCollide, setLeftCollide] = useState(leftBound);
+  const [rightCollide, setRightCollide] = useState(rightBound);
 
   const animationRef = useRef();
-  const circleRef = useRef();
+  const ringRef = useRef();
 
   const slowControls = useAnimation();
   const fastControls = useAnimation();
@@ -38,11 +39,29 @@ function Animation() {
   const slowY = [0, altitude, 0];
   const fastY = [0, -altitude, 0];
 
-  const onClick = () => {
-    rightBound = animationRef.current.offsetWidth
-      - circleRef.current.offsetWidth;
+  const [trips, setTrips] = useState(0);
+  const [cur, setCur] = useState(1);
+  const [prev, setPrev] = useState(1);
 
-    console.log(rightBound);
+  function onUpdate(latest) {
+    setCur(latest.x < leftCollide || latest.x > rightCollide? 1:0);
+
+    if (cur === 1 && prev === 0) {
+      setTrips(trips+1);
+    }
+
+    setPrev(cur);
+  }
+
+  const onClick = () => {
+    setTrips(0);
+
+    const ringDiameter = ringRef.current.offsetWidth;
+
+    rightBound = animationRef.current.offsetWidth - ringDiameter;
+
+    setLeftCollide(leftBound + ringDiameter);
+    setRightCollide(rightBound - ringDiameter);
 
     const xBounds = [leftBound, rightBound];
 
@@ -63,7 +82,7 @@ function Animation() {
         <div className="yellowBox"></div>
         <div className="planeName">Mach 5 vs. Today's Planes</div>
         <div className="animationBox"></div>
-        <div className="tripCounter">Oneway trips: {trips}</div>
+        <div className="tripCounter">One-way trips: {trips}</div>
       </div>
       <div className="row">
         <div className="box"></div>
@@ -86,8 +105,9 @@ function Animation() {
                 duration: fastPlaneSpeed,
                 flip: howMuchSlower - 1,
               }}
+              onUpdate={onUpdate}
             />
-          <div ref={circleRef} className="ring"/>
+          <div ref={ringRef} className="ring"/>
         </div>
         <div className="cityLabel">Paris</div>
       </div>


### PR DESCRIPTION
Fixes issue #2 

Initially, I was thinking about a traditional 2d collision detection
system like here:

<https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection>

But after thinking about it, my app only needs to know if the flying
circle has passed certain coordinates.  The flying circle is constrained
to a simple flight path and only hits the destination rings from one
side.  If the flying circle had to approach from any side and was
allowed an arbitrary flight path, I would have to switch to traditional
collision detection.

The current system for incrementing the trip counter is based on
detecting when the flying circle transitions between three different
rectangular regions: the region including the left ring at the right
x-coordinate of the ring, the region between the two rings, and the
region including the right ring at the left x-coordinate of the right
ring.

Mathematically, the simple system detects when the flying circle moves
past a vertical line located at the right edge of the left ring and a
vertical line located at the left edge of the right ring.

But it only registers a collision when the flying circle is moving _out_
of the region between the two rings.  If I didn't do this, the trip
counter would register a trip right when the animation started because
the flying circle starts outside this region.