### PR TITLE
Fully reset initial state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,9 +40,10 @@ function Animation() {
   const slowY = [0, altitude, 0];
   const fastY = [0, -altitude, 0];
 
-  const [trips, setTrips] = useState(0);
-  const [cur, setCur] = useState(1);
-  const [prev, setPrev] = useState(1);
+  const [curInit, prevInit, tripsInit] = [1, 1, 0];
+  const [trips, setTrips] = useState(tripsInit);
+  const [cur, setCur] = useState(curInit);
+  const [prev, setPrev] = useState(prevInit);
 
   function onUpdate(latest) {
     setCur(latest.x < leftCollide || latest.x > rightCollide? 1:0);
@@ -55,7 +56,9 @@ function Animation() {
   }
 
   const onClick = () => {
-    setTrips(0);
+    setCur(curInit);
+    setPrev(prevInit);
+    setTrips(tripsInit);
 
     const ringDiameter = ringRef.current.offsetWidth;
 


### PR DESCRIPTION
If you restart the animation while the circle is between the rings, the
counter "seems" to start at 1.  This is because `cur` and `prev` are not
reset to initial values.  The if statement in `onClick` detects an
erroneous transition and quickly sets the counter to 1 in the first
frame.